### PR TITLE
Pass CLI exit code to Actions

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,12 +16,12 @@ fi
 
 eval $command
 
-$ret=$?
+ret=$?
 
 echo "exit code: $ret"
 
 if [ $ret -ne 0 ]; then
-  exit $?
+  exit $ret
 fi
 
 if [ "true" == "$7" ];then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,7 +15,12 @@ if [ -n "$6" ];then
 fi
 
 eval $command
-if [ $? -ne 0 ]; then
+
+$ret=$?
+
+echo "exit code: $ret"
+
+if [ $ret -ne 0 ]; then
   exit $?
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,9 +17,6 @@ fi
 eval $command
 
 ret=$?
-
-echo "exit code: $ret"
-
 if [ $ret -ne 0 ]; then
   exit $ret
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,6 +15,9 @@ if [ -n "$6" ];then
 fi
 
 eval $command
+if [ $? -ne 0 ]; then
+  exit $?
+fi
 
 if [ "true" == "$7" ];then
   . /.pscale/cli-helper-scripts/wait-for-branch-readiness.sh

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
       - name: Create a branch
-        uses: planetscale/create-branch-action@v1
+        uses: planetscale/create-branch-action@v2
         id: create_branch
         with:
           org_name: bmorrison-ps


### PR DESCRIPTION
This update will pass the exit code from the CLI operations up to the Actions platform. This will properly flag the workflow step as a failure if something goes wrong while executing.