### PR TITLE
Add `check_exists` option

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -39,4 +39,4 @@ runs:
     - ${{ inputs.restore }}
     - ${{ inputs.region }}
     - ${{ inputs.wait }}
-    - ${{ inputs.allow_duplicate }}
+    - ${{ inputs.check_exists }}

--- a/action.yaml
+++ b/action.yaml
@@ -25,6 +25,9 @@ inputs:
   wait:
     description: 'If set to "true", the action will wait until the branch is finished initializing before exiting.'
     required: false
+  check_exists:
+    description: "If set to \"true\", the action won't create the branch when it already exists."
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -36,3 +39,4 @@ runs:
     - ${{ inputs.restore }}
     - ${{ inputs.region }}
     - ${{ inputs.wait }}
+    - ${{ inputs.allow_duplicate }}

--- a/action.yaml
+++ b/action.yaml
@@ -26,7 +26,7 @@ inputs:
     description: 'If set to "true", the action will wait until the branch is finished initializing before exiting.'
     required: false
   check_exists:
-    description: "If set to \"true\", the action won't create the branch when it already exists."
+    description: "If set to \"true\", the action won't create the branch if it already exists."
     required: false
 runs:
   using: 'docker'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,8 +21,6 @@ echo $8
 if [ "true" == "$8" ];then
   output=$(eval "pscale branch show $1 $2 --org $3" 2>&1)
   exit_status=$?
-  echo $output
-  echo $exit_status
   if [ $exit_status -ne 0 ]; then
     create_branch=true
   else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,7 +26,7 @@ if [ "true" == "$8" ];then
   fi
 fi
 
-if create_branch; then
+if $create_branch; then
   eval $command
 
   ret=$?

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+create_branch=true
 command="pscale branch create $1 $2 --org $3"
 
 if [ -n "$4" ];then
@@ -14,14 +15,29 @@ if [ -n "$6" ];then
   command="$command --region $6"
 fi
 
-eval $command
-
-ret=$?
-if [ $ret -ne 0 ]; then
-  exit $ret
+# Check if branch already exists
+if [ "true" == "$8" ];then
+  output=$(eval "pscale branch show $1 $2 --org $3" 2>&1)
+  exit_status=$?
+  if [ $exit_status -ne 0 ]; then
+    create_branch=true
+  else
+    create_branch=false
+  fi
 fi
 
-if [ "true" == "$7" ];then
-  . /.pscale/cli-helper-scripts/wait-for-branch-readiness.sh
-  wait_for_branch_readiness 10 "$1" "$2" "$3" 20
+if create_branch; then
+  eval $command
+
+  ret=$?
+  if [ $ret -ne 0 ]; then
+    exit $ret
+  fi
+
+  if [ "true" == "$7" ];then
+    . /.pscale/cli-helper-scripts/wait-for-branch-readiness.sh
+    wait_for_branch_readiness 10 "$1" "$2" "$3" 20
+  fi
+else
+  echo "Branch $2 already exists"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,6 +15,8 @@ if [ -n "$6" ];then
   command="$command --region $6"
 fi
 
+echo $8
+
 # Check if branch already exists
 if [ "true" == "$8" ];then
   output=$(eval "pscale branch show $1 $2 --org $3" 2>&1)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,7 +36,7 @@ if $create_branch; then
 
   if [ "true" == "$7" ];then
     . /.pscale/cli-helper-scripts/wait-for-branch-readiness.sh
-    wait_for_branch_readiness 10 "$1" "$2" "$3" 20
+    wait_for_branch_readiness 40 "$1" "$2" "$3" 5
   fi
 else
   echo "Branch $2 already exists"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,6 +19,8 @@ fi
 if [ "true" == "$8" ];then
   output=$(eval "pscale branch show $1 $2 --org $3" 2>&1)
   exit_status=$?
+  echo $output
+  echo $exit_status
   if [ $exit_status -ne 0 ]; then
     create_branch=true
   else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,8 +15,6 @@ if [ -n "$6" ];then
   command="$command --region $6"
 fi
 
-echo $8
-
 # Check if branch already exists
 if [ "true" == "$8" ];then
   output=$(eval "pscale branch show $1 $2 --org $3" 2>&1)

--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,7 @@ jobs:
 - `restore` - The ID of the backup that will be restored to the new branch. If not set, no backup will be restored.
 - `region` - The region to create the new branch in. Defaults to the region where the `from` branch currently is.
 - `wait` - If this value is set to "true", the action will ensure that the branch is created before exiting. If not, the action will exit immediately once the PlanetScale service has received the command to create the branch.
+- `check_exists` - If set to "true", the action won't create the branch if it already exists.
 
 ## Outputs
 


### PR DESCRIPTION
New option that will check if the branch exists before trying to create it.

This way, if the branch already exists, the script won't return a non-zero exit code.

Useful if running on every push to a pull request.